### PR TITLE
Ensign Shuttle Pilot

### DIFF
--- a/maps/torch/job/exploration_jobs.dm
+++ b/maps/torch/job/exploration_jobs.dm
@@ -60,9 +60,8 @@
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/civ/contractor = /decl/hierarchy/outfit/job/torch/passenger/research/nt_pilot,
-		/datum/mil_rank/ec/e7,
-		/datum/mil_rank/fleet/e6,
-		/datum/mil_rank/fleet/e7
+		/datum/mil_rank/ec/o1,
+		/datum/mil_rank/fleet/o1
 	)
 
 	access = list(


### PR DESCRIPTION
Self-explanatory.  Removes enlisted ranks and adds the O-1 commissioned officer rank for explo's shuttle pilot.  Decided to do this since SOP states "Pilots have authority over their respective craft while aboard them, but should keep the Deck Chief informed of ship movement, through flight plans or direct, acknowledged contact.", which generally doesn't happen since the Pathfinder and deck chief can both pull rank over the pilot.


This should work somewhat similarly to how CM handles pilots.  That being, they have control over any enlisted onboard their ship, but unless there's no Pathfinder shouldn't be giving orders to people outside during the away mission.


Changelog:
Gave shuttle pilots EC and Fleet O-1 (Ensign) rank options
Removed EC and Fleet E-7 (CXPL and CPO) and E-6 (PO1) rank options from shuttle pilot

